### PR TITLE
Mark Go package as deprecated in favour of popui.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,4 +3,4 @@
 // (e.g. github.com/invopop/popui/go/props becomes github.com/invopop/popui.go/props).
 module github.com/invopop/popui
 
-go 1.23.0
+go 1.23

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
 // Deprecated: The popui Go library has moved to github.com/invopop/popui.go.
-// Replace imports of github.com/invopop/popui with github.com/invopop/popui.go.
+// Replace imports of github.com/invopop/popui/go with github.com/invopop/popui.go
+// (e.g. github.com/invopop/popui/go/props becomes github.com/invopop/popui.go/props).
 module github.com/invopop/popui
 
 go 1.23.0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+// Deprecated: The popui Go library has moved to github.com/invopop/popui.go.
+// Replace imports of github.com/invopop/popui with github.com/invopop/popui.go.
+module github.com/invopop/popui
+
+go 1.23.0

--- a/go/alpine/doc.go
+++ b/go/alpine/doc.go
@@ -1,0 +1,6 @@
+// Package alpine provided the Alpine.js-backed POPUI Go components.
+//
+// Deprecated: The popui Go library has moved to github.com/invopop/popui.go.
+// Update imports from "github.com/invopop/popui/go/alpine" to
+// "github.com/invopop/popui.go/alpine".
+package alpine

--- a/go/alpine/doc.go
+++ b/go/alpine/doc.go
@@ -1,6 +1,5 @@
-// Package alpine provided the Alpine.js-backed POPUI Go components.
+// Package alpine has moved to github.com/invopop/popui.go/alpine.
 //
-// Deprecated: The popui Go library has moved to github.com/invopop/popui.go.
-// Update imports from "github.com/invopop/popui/go/alpine" to
+// Deprecated: Update imports from "github.com/invopop/popui/go/alpine" to
 // "github.com/invopop/popui.go/alpine".
 package alpine

--- a/go/classes/doc.go
+++ b/go/classes/doc.go
@@ -1,0 +1,6 @@
+// Package classes provided the CSS class helpers for the POPUI Go components.
+//
+// Deprecated: The popui Go library has moved to github.com/invopop/popui.go.
+// Update imports from "github.com/invopop/popui/go/classes" to
+// "github.com/invopop/popui.go/classes".
+package classes

--- a/go/classes/doc.go
+++ b/go/classes/doc.go
@@ -1,6 +1,5 @@
-// Package classes provided the CSS class helpers for the POPUI Go components.
+// Package classes has moved to github.com/invopop/popui.go/classes.
 //
-// Deprecated: The popui Go library has moved to github.com/invopop/popui.go.
-// Update imports from "github.com/invopop/popui/go/classes" to
+// Deprecated: Update imports from "github.com/invopop/popui/go/classes" to
 // "github.com/invopop/popui.go/classes".
 package classes

--- a/go/doc.go
+++ b/go/doc.go
@@ -1,0 +1,7 @@
+// Package popui provided the Templ components and support functions required to
+// use POPUI in a Go application.
+//
+// Deprecated: The popui Go library has moved to github.com/invopop/popui.go.
+// Update imports from "github.com/invopop/popui/go" to
+// "github.com/invopop/popui.go".
+package popui

--- a/go/doc.go
+++ b/go/doc.go
@@ -1,7 +1,5 @@
-// Package popui provided the Templ components and support functions required to
-// use POPUI in a Go application.
+// Package popui has moved to github.com/invopop/popui.go.
 //
-// Deprecated: The popui Go library has moved to github.com/invopop/popui.go.
-// Update imports from "github.com/invopop/popui/go" to
+// Deprecated: Update imports from "github.com/invopop/popui/go" to
 // "github.com/invopop/popui.go".
 package popui

--- a/go/flash/doc.go
+++ b/go/flash/doc.go
@@ -1,6 +1,5 @@
-// Package flash provided the flash-message helpers for the POPUI Go components.
+// Package flash has moved to github.com/invopop/popui.go/flash.
 //
-// Deprecated: The popui Go library has moved to github.com/invopop/popui.go.
-// Update imports from "github.com/invopop/popui/go/flash" to
+// Deprecated: Update imports from "github.com/invopop/popui/go/flash" to
 // "github.com/invopop/popui.go/flash".
 package flash

--- a/go/flash/doc.go
+++ b/go/flash/doc.go
@@ -1,0 +1,6 @@
+// Package flash provided the flash-message helpers for the POPUI Go components.
+//
+// Deprecated: The popui Go library has moved to github.com/invopop/popui.go.
+// Update imports from "github.com/invopop/popui/go/flash" to
+// "github.com/invopop/popui.go/flash".
+package flash

--- a/go/props/doc.go
+++ b/go/props/doc.go
@@ -1,0 +1,6 @@
+// Package props provided the property types for the POPUI Go components.
+//
+// Deprecated: The popui Go library has moved to github.com/invopop/popui.go.
+// Update imports from "github.com/invopop/popui/go/props" to
+// "github.com/invopop/popui.go/props".
+package props

--- a/go/props/doc.go
+++ b/go/props/doc.go
@@ -1,6 +1,5 @@
-// Package props provided the property types for the POPUI Go components.
+// Package props has moved to github.com/invopop/popui.go/props.
 //
-// Deprecated: The popui Go library has moved to github.com/invopop/popui.go.
-// Update imports from "github.com/invopop/popui/go/props" to
+// Deprecated: Update imports from "github.com/invopop/popui/go/props" to
 // "github.com/invopop/popui.go/props".
 package props


### PR DESCRIPTION
The Go library was moved to [github.com/invopop/popui.go](https://github.com/invopop/popui.go), and all Go sources were removed from this repo. But consumers still importing the old `github.com/invopop/popui/go` paths got **no signal** that it was gone. They now see deprecation at the path level and at the module level like so:

| Old path (flagged on import) | Points to |
|---|---|
| `github.com/invopop/popui/go` | `github.com/invopop/popui.go` |
| `github.com/invopop/popui/go/props` | `github.com/invopop/popui.go/props` |
| `github.com/invopop/popui/go/classes` | `github.com/invopop/popui.go/classes` |
| `github.com/invopop/popui/go/alpine` | `github.com/invopop/popui.go/alpine` |
| `github.com/invopop/popui/go/flash` | `github.com/invopop/popui.go/flash` |

**Module-level deprecation** — root `go.mod` with a `// Deprecated:` directive above the `module` line, so `go get` / `go list -m -u` / pkg.go.dev warn too.
